### PR TITLE
Add VibeThreads e-commerce demo site

### DIFF
--- a/vibethreads/about.html
+++ b/vibethreads/about.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About – VibeThreads</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <img src="https://picsum.photos/seed/vibethreadslogo/300/80" alt="VibeThreads logo">
+        <h1>About VibeThreads</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+    </nav>
+    <section class="container" style="padding:60px 20px;">
+        <p>Born from the energy of the streets, VibeThreads brings you limited-run apparel with vivid colors and fearless designs. Our mission is to empower you to express your true self through bold fashion.</p>
+    </section>
+    <footer class="footer">
+        &copy; 2025 VibeThreads. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/vibethreads/contact.html
+++ b/vibethreads/contact.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact – VibeThreads</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <img src="https://picsum.photos/seed/vibethreadslogo/300/80" alt="VibeThreads logo">
+        <h1>Get in Touch</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+    </nav>
+    <section class="container" style="padding:60px 20px;">
+        <form>
+            <div style="margin-bottom:15px;">
+                <input type="text" placeholder="Name" style="width:100%;padding:10px;">
+            </div>
+            <div style="margin-bottom:15px;">
+                <input type="email" placeholder="Email" style="width:100%;padding:10px;">
+            </div>
+            <div style="margin-bottom:15px;">
+                <textarea placeholder="Message" rows="5" style="width:100%;padding:10px;"></textarea>
+            </div>
+            <button class="cta" type="submit">Send</button>
+        </form>
+    </section>
+    <footer class="footer">
+        &copy; 2025 VibeThreads. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/vibethreads/index.html
+++ b/vibethreads/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VibeThreads – Bold Streetwear</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <img src="https://picsum.photos/seed/vibethreadslogo/300/80" alt="VibeThreads logo">
+        <h1>Live Loud, Wear Vivid</h1>
+        <a href="shop.html" class="btn cta">Shop Now</a>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+    </nav>
+    <section class="hero container">
+        <p>Welcome to VibeThreads, your source for colorful, limited-run streetwear designed to make a statement.</p>
+    </section>
+    <section class="product-grid">
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/shirt1/300/250" alt="Vivid Tee">
+            <h3>Vivid Tee</h3>
+            <p>$29.99</p>
+            <a href="product.html" class="btn">View</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/shirt2/300/250" alt="Hype Hoodie">
+            <h3>Hype Hoodie</h3>
+            <p>$59.99</p>
+            <a href="product.html" class="btn">View</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/shirt3/300/250" alt="Splash Cap">
+            <h3>Splash Cap</h3>
+            <p>$19.99</p>
+            <a href="product.html" class="btn">View</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/shirt4/300/250" alt="Glow Joggers">
+            <h3>Glow Joggers</h3>
+            <p>$49.99</p>
+            <a href="product.html" class="btn">View</a>
+        </div>
+    </section>
+    <footer class="footer">
+        &copy; 2025 VibeThreads. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/vibethreads/product.html
+++ b/vibethreads/product.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Product – VibeThreads</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <img src="https://picsum.photos/seed/vibethreadslogo/300/80" alt="VibeThreads logo">
+        <h1>Product Detail</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+    </nav>
+    <section class="container" style="padding:60px 20px;">
+        <div style="display:flex;flex-wrap:wrap;gap:40px;">
+            <img src="https://picsum.photos/seed/productdetail/500/400" alt="Product Image" style="flex:1;min-width:250px;">
+            <div style="flex:1;min-width:250px;">
+                <h2>Hype Hoodie</h2>
+                <p style="font-size:20px;font-weight:bold;">$59.99</p>
+                <p>The Hype Hoodie features vibrant prints and premium materials so you can stand out from the crowd.</p>
+                <button class="cta">Add to Cart</button>
+            </div>
+        </div>
+    </section>
+    <footer class="footer">
+        &copy; 2025 VibeThreads. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/vibethreads/shop.html
+++ b/vibethreads/shop.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shop – VibeThreads</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <img src="https://picsum.photos/seed/vibethreadslogo/300/80" alt="VibeThreads logo">
+        <h1>Shop VibeThreads</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+    </nav>
+    <section class="product-grid">
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/product1/300/250" alt="Burst Tee">
+            <h3>Burst Tee</h3>
+            <p>$29.99</p>
+            <a href="product.html" class="btn">Details</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/product2/300/250" alt="Neon Crew">
+            <h3>Neon Crew</h3>
+            <p>$39.99</p>
+            <a href="product.html" class="btn">Details</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/product3/300/250" alt="Ink Hoodie">
+            <h3>Ink Hoodie</h3>
+            <p>$64.99</p>
+            <a href="product.html" class="btn">Details</a>
+        </div>
+        <div class="product-card">
+            <img src="https://picsum.photos/seed/product4/300/250" alt="Glow Joggers">
+            <h3>Glow Joggers</h3>
+            <p>$49.99</p>
+            <a href="product.html" class="btn">Details</a>
+        </div>
+    </section>
+    <footer class="footer">
+        &copy; 2025 VibeThreads. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/vibethreads/style.css
+++ b/vibethreads/style.css
@@ -1,0 +1,106 @@
+/* VibeThreads E-commerce Website Styles */
+@import url('https://fonts.googleapis.com/css2?family=Exo+2:wght@400;700;800&display=swap');
+
+body {
+    margin: 0;
+    font-family: 'Exo 2', sans-serif;
+    background-color: #111;
+    color: #f5f5f5;
+    line-height: 1.6;
+}
+
+header {
+    background: #1c1c1c;
+    padding: 40px 20px;
+    text-align: center;
+}
+
+header img {
+    max-width: 180px;
+    margin-bottom: 10px;
+}
+
+h1 {
+    font-weight: 800;
+    color: #ff6b6b;
+    font-size: 48px;
+    margin: 20px 0;
+}
+
+nav {
+    background-color: #000;
+    padding: 10px 20px;
+    text-align: center;
+}
+
+nav a {
+    color: #f5f5f5;
+    margin: 0 10px;
+    text-decoration: none;
+    font-weight: 700;
+}
+
+nav a:hover {
+    color: #ff6b6b;
+}
+
+.hero {
+    padding: 60px 20px;
+    text-align: center;
+}
+
+.cta {
+    background-color: #ff6b6b;
+    color: #111;
+    padding: 12px 40px;
+    font-weight: bold;
+    border: none;
+    cursor: pointer;
+    margin-top: 20px;
+    font-size: 18px;
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 20px;
+    padding: 60px 20px;
+}
+
+.product-card {
+    background-color: #1c1c1c;
+    padding: 20px;
+    border: 2px solid #ff6b6b;
+    text-align: center;
+}
+
+.product-card img {
+    width: 100%;
+    height: auto;
+}
+
+.footer {
+    text-align: center;
+    padding: 20px;
+    background-color: #000;
+    font-size: 14px;
+}
+
+/* Utility */
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.btn {
+    display: inline-block;
+    background-color: #ff6b6b;
+    color: #111;
+    padding: 10px 20px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.btn:hover {
+    background-color: #ff8787;
+}


### PR DESCRIPTION
## Summary
- add `vibethreads` folder with sample e‑commerce pages
- provide a shared stylesheet with vibrant theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dc535aaa48325b60681525b2bd55a