### PR TITLE
Add WordPress landing page template with enqueued assets

### DIFF
--- a/vibethreads/assets/css/landing.css
+++ b/vibethreads/assets/css/landing.css
@@ -1,0 +1,146 @@
+body {
+    margin: 0;
+    font-family: 'Exo 2', sans-serif;
+    background-color: #0A0A11;
+    color: #E8E8E8;
+    line-height: 1.6;
+}
+header {
+    background-color: #141A1F;
+    padding: 40px 20px;
+    text-align: center;
+}
+header img {
+    max-width: 180px;
+    margin-bottom: 10px;
+}
+h1 {
+    font-weight: 800;
+    color: #03F7C4;
+    font-size: 48px;
+    margin: 20px 0;
+}
+.cta {
+    background-color: #03F7C4;
+    color: #0A0A11;
+    padding: 10px 30px;
+    font-weight: bold;
+    border: none;
+    cursor: pointer;
+    margin-top: 20px;
+    font-size: 18px;
+}
+nav {
+    background-color: #0A0A11;
+    padding: 10px 20px;
+    text-align: center;
+}
+nav a {
+    color: #E8E8E8;
+    margin: 0 10px;
+    text-decoration: none;
+    font-weight: 700;
+}
+nav a:hover {
+    color: #03F7C4;
+}
+.hero {
+    padding: 60px 20px;
+    text-align: center;
+}
+.category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    padding: 60px 20px;
+    background-color: #141A1F;
+}
+.category-tile {
+    background-color: #07816B;
+    padding: 40px 20px;
+    text-align: center;
+    font-size: 20px;
+    font-weight: bold;
+    color: #fff;
+}
+.featured-section {
+    padding: 60px 20px;
+    background-color: #0A0A11;
+}
+.featured-section h2 {
+    color: #F9B12C;
+    font-size: 32px;
+    margin-bottom: 20px;
+    text-align: center;
+}
+.product-row {
+    display: flex;
+    gap: 20px;
+    overflow-x: auto;
+    padding-bottom: 10px;
+}
+.product-card {
+    background-color: #141A1F;
+    padding: 20px;
+    min-width: 200px;
+    border: 1px solid #03F7C4;
+}
+.about-section {
+    background-color: #141A1F;
+    padding: 60px 20px;
+    text-align: center;
+}
+.about-section h2 {
+    color: #03F7C4;
+    font-size: 32px;
+    margin-bottom: 20px;
+}
+.quote-block {
+    background-color: #4D402B;
+    padding: 40px 20px;
+    text-align: center;
+    font-size: 24px;
+    font-style: italic;
+}
+.testimonial-section {
+    background-color: #141A1F;
+    padding: 60px 20px;
+}
+.testimonial-section h2 {
+    text-align: center;
+    color: #F9B12C;
+    font-size: 32px;
+    margin-bottom: 20px;
+}
+.testimonial {
+    background-color: #0A0A11;
+    padding: 20px;
+    margin: 20px auto;
+    max-width: 600px;
+    border: 1px solid #03F7C4;
+}
+.email-signup {
+    background-color: #141A1F;
+    padding: 60px 20px;
+    text-align: center;
+}
+.email-signup input {
+    padding: 10px;
+    font-size: 16px;
+    margin-right: 10px;
+    width: 250px;
+}
+.email-signup button {
+    padding: 10px 20px;
+    background-color: #03F7C4;
+    color: #0A0A11;
+    font-weight: bold;
+    border: none;
+    cursor: pointer;
+}
+footer {
+    text-align: center;
+    padding: 20px;
+    background-color: #0A0A11;
+    font-size: 14px;
+}

--- a/vibethreads/assets/js/landing.js
+++ b/vibethreads/assets/js/landing.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const cta = document.querySelector('.cta');
+    if (cta) {
+        cta.addEventListener('click', () => {
+            document.getElementById('featured')?.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
+});

--- a/vibethreads/footer.php
+++ b/vibethreads/footer.php
@@ -1,0 +1,6 @@
+<footer>
+    &copy; <?php echo date('Y'); ?> Cebastian Co. – All Rights Reserved.
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/vibethreads/functions.php
+++ b/vibethreads/functions.php
@@ -1,0 +1,9 @@
+<?php
+function vibethreads_enqueue_assets() {
+    wp_enqueue_style('vibethreads-style', get_stylesheet_uri());
+    wp_enqueue_style('google-fonts', 'https://fonts.googleapis.com/css2?family=Exo+2:wght@400;700;800&display=swap', [], null);
+    wp_enqueue_style('vibethreads-landing', get_template_directory_uri() . '/assets/css/landing.css', ['vibethreads-style'], '1.0');
+    wp_enqueue_script('vibethreads-landing', get_template_directory_uri() . '/assets/js/landing.js', [], '1.0', true);
+}
+add_action('wp_enqueue_scripts', 'vibethreads_enqueue_assets');
+?>

--- a/vibethreads/header.php
+++ b/vibethreads/header.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo('charset'); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header>
+    <img src="<?php echo esc_url( get_template_directory_uri() . '/cebastianco_name_mark_logo_gold.jpeg' ); ?>" alt="Cebastian Co. Logo">
+    <h1>New Drops, No Excuses</h1>
+    <button class="cta">Shop The Hype</button>
+</header>
+<nav>
+    <a href="#categories">Categories</a>
+    <a href="#featured">Featured</a>
+    <a href="#about">About</a>
+    <a href="#testimonials">Testimonials</a>
+    <a href="#newsletter">Newsletter</a>
+</nav>

--- a/vibethreads/page-landing.php
+++ b/vibethreads/page-landing.php
@@ -1,0 +1,56 @@
+<?php
+/* Template Name: Landing Page */
+get_header();
+?>
+<div class="elementor-section">
+    <section class="hero">
+        <p>Welcome to Cebastian Co., the home of limited streetwear drops. Elevate your style with exclusive pieces crafted to turn heads.</p>
+    </section>
+</div>
+<div class="elementor-section">
+    <section id="categories" class="category-grid">
+        <div class="category-tile">Hoodies</div>
+        <div class="category-tile">Tees</div>
+        <div class="category-tile">Accessories</div>
+        <div class="category-tile">Limited</div>
+        <div class="category-tile">Sale</div>
+        <div class="category-tile">Lookbook</div>
+    </section>
+</div>
+<div class="elementor-section">
+    <section id="featured" class="featured-section">
+        <h2>Featured Drops</h2>
+        <div class="product-row">
+            <div class="product-card">Product 1</div>
+            <div class="product-card">Product 2</div>
+            <div class="product-card">Product 3</div>
+            <div class="product-card">Product 4</div>
+        </div>
+    </section>
+</div>
+<div class="elementor-section">
+    <section id="about" class="about-section">
+        <h2>Our Story</h2>
+        <p>Born from a love of music and street culture, Cebastian Co. brings bold designs that speak volumes. Each drop is crafted in small batches so you can stand out from the crowd.</p>
+    </section>
+</div>
+<div class="elementor-section">
+    <section class="quote-block">
+        “Worn Out Loud. Never Watered Down.”
+    </section>
+</div>
+<div class="elementor-section">
+    <section id="testimonials" class="testimonial-section">
+        <h2>What People Are Saying</h2>
+        <div class="testimonial">"The quality is unmatched and the designs are fire. Can't wait for the next drop!" – Jordan</div>
+        <div class="testimonial">"Finally found a brand that gets me. Everything just hits different." – Riley</div>
+    </section>
+</div>
+<div class="elementor-section">
+    <section id="newsletter" class="email-signup">
+        <p>Hit That Inbox</p>
+        <input type="email" placeholder="Your email...">
+        <button>Sign Up</button>
+    </section>
+</div>
+<?php get_footer(); ?>

--- a/vibethreads/style.css
+++ b/vibethreads/style.css
@@ -1,5 +1,7 @@
-/* VibeThreads E-commerce Website Styles */
-@import url('https://fonts.googleapis.com/css2?family=Exo+2:wght@400;700;800&display=swap');
+/*
+Theme Name: VibeThreads
+Text Domain: vibethreads
+*/
 
 body {
     margin: 0;


### PR DESCRIPTION
## Summary
- Add landing page template wrapped in Elementor sections
- Enqueue Google Fonts, stylesheet, and script via functions.php
- Move inline styles and scripts into dedicated asset files

## Testing
- `php -l vibethreads/functions.php`
- `php -l vibethreads/header.php`
- `php -l vibethreads/footer.php`
- `php -l vibethreads/page-landing.php`


------
https://chatgpt.com/codex/tasks/task_e_688deb88ab6483258fb66f66aa22322b