### PR TITLE
Add HTML linting workflow

### DIFF
--- a/.github/workflows/html-lint.yml
+++ b/.github/workflows/html-lint.yml
@@ -1,0 +1,18 @@
+name: HTML Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install HTMLHint
+        run: npm install --no-save htmlhint
+      - name: Run HTMLHint
+        run: npx htmlhint "**/*.html"


### PR DESCRIPTION
## Summary
- add HTML linting GitHub Actions workflow using HTMLHint
- ensure Node is set up and HTMLHint is installed before linting

## Testing
- `npm install --no-save htmlhint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx htmlhint "**/*.html"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `python -m compileall $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689178dbbee48325a08043814c3accbc