### PR TITLE
Add CSS accessibility tests and update focus outlines

### DIFF
--- a/test/additional-css.test.js
+++ b/test/additional-css.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const cssPath = path.join(__dirname, '..', 'wordpress', 'cebastian', 'additional-css.css');
+const css = fs.readFileSync(cssPath, 'utf8');
+
+test('Additional CSS has balanced braces', () => {
+  const openings = (css.match(/\{/g) || []).length;
+  const closings = (css.match(/\}/g) || []).length;
+  assert.strictEqual(openings, closings, 'CSS braces must be balanced to avoid broken styles.');
+});
+
+test('Additional CSS keeps focus outlines and supports keyboard navigation', () => {
+  assert.ok(!/outline\s*:\s*none/.test(css), 'Focus outlines should never be removed outright for accessibility.');
+  const focusVisibleBlock = css.match(/:focus-visible\s*\{[^}]+\}/);
+  assert.ok(focusVisibleBlock, 'Expected :focus-visible styles to aid keyboard users.');
+  assert.ok(/outline/.test(focusVisibleBlock[0]), 'Focus-visible styles must include an outline declaration.');
+  assert.ok(css.includes('.skip-link'), 'Skip link styles are required for quick content access.');
+});
+
+test('Additional CSS respects reduced motion preferences', () => {
+  const reducedMotionBlock = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*\{[\s\S]*?\}/);
+  assert.ok(reducedMotionBlock, 'Expected a prefers-reduced-motion media query to limit animations.');
+  assert.ok(/animation:\s*none\s*!important/.test(reducedMotionBlock[0]), 'Reduced motion block should disable animations.');
+});
+
+test('Additional CSS uses valid hex color values', () => {
+  const hexMatches = css.match(/#[0-9a-fA-F]+/g) || [];
+  const allowedLengths = new Set([4, 7, 9]);
+  for (const hex of hexMatches) {
+    assert.ok(allowedLengths.has(hex.length), `Unexpected hex color format detected: ${hex}`);
+  }
+});

--- a/wordpress/cebastian/about.html
+++ b/wordpress/cebastian/about.html
@@ -1,0 +1,136 @@
+<!-- CEBASTIAN Co. – About Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="about-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">About CEBASTIAN</p>
+            <h1 id="about-title" class="kdn-title">Forged Between Myth &amp; Metropolis</h1>
+            <p class="kdn-subtitle">CEBASTIAN Co. is a luxury streetwear house built on the belief that legends live among us. We weave folklore into modern silhouettes, championing craftsmanship, inclusivity, and sustainability.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--2">
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Origin Story</h2>
+                <p class="kdn-card__text">Our founder, Sebastian Cruz, grew up between Bogotá and Brooklyn, sketching armor inspired by Andean myths and cyberpunk cinema. CEBASTIAN launched in 2017 with a self-funded micro drop that sold out overnight. Today, we operate a hybrid studio that blends couture tailors, textile scientists, and digital artists crafting AR-enhanced garments.</p>
+                <p class="kdn-card__text">Every capsule is a narrative arc—prologues release in our newsletter, chapters unfold with each drop, and epilogues live in immersive experiences.</p>
+            </article>
+            <article class="kdn-card kdn-animate" id="craft">
+                <h2 class="kdn-card__title">Design Philosophy</h2>
+                <p class="kdn-card__text">We call it <em>mythic utility</em>. Expect hidden pockets, reinforced seams, and ergonomic patterning disguised within sculptural forms. Our atelier iterates on 3D prototypes, stress-tests in VR, then crafts the final garments by hand.</p>
+                <ul class="kdn-card__text" style="margin-top:1rem; list-style:none; display:grid; gap:0.75rem; padding:0;">
+                    <li>• Laser-cut panels aligned with human kinetic maps.</li>
+                    <li>• Integrated RFID tags for authenticity and story unlocks.</li>
+                    <li>• Vegan leather alternatives sourced from cactus fiber.</li>
+                </ul>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" id="community" aria-labelledby="community-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Community</span>
+            <h2 id="community-title" class="kdn-title">The Vanguard Collective</h2>
+            <p class="kdn-subtitle">Our community guides every drop. From Discord votes to pop-up quests, the Vanguard co-creates experiences that celebrate global street culture.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">Digital Quests</span>
+                <h3 class="kdn-card__title">Interactive Lore</h3>
+                <p class="kdn-card__text">Solve ARG missions to unlock early access and digital wearables for your avatars.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">IRL Events</span>
+                <h3 class="kdn-card__title">Pop-up Sanctuaries</h3>
+                <p class="kdn-card__text">Immersive installations in Seoul, Mexico City, and Berlin pair garments with projection art.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">Creator Support</span>
+                <h3 class="kdn-card__title">Residencies</h3>
+                <p class="kdn-card__text">We sponsor emerging artists with studio grants, culminating in capsule collaborations.</p>
+            </article>
+        </div>
+        <div style="text-align:center; margin-top:2.5rem;" class="kdn-animate">
+            <a class="kdn-btn kdn-btn--primary" href="/contact/#press">Request a Collaboration Deck</a>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" id="sustainability" aria-labelledby="sustainability-title">
+    <div class="kdn-container">
+        <div class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Sustainability</span>
+            <h2 id="sustainability-title" class="kdn-title">Guardians of the Realm</h2>
+            <p class="kdn-subtitle">Our sustainability strategy is rooted in reciprocity—we give back to the lands and communities that inspire our stories.</p>
+        </div>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Circular Fabric Lab</h3>
+                <p class="kdn-card__text">We upcycle production offcuts into modular accessories and donate surplus to youth design programs.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Carbon Neutral Logistics</h3>
+                <p class="kdn-card__text">Shipments are offset via verified reforestation initiatives in Colombia and Iceland.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Ethical Supply Chain</h3>
+                <p class="kdn-card__text">Our partners are audited annually to ensure fair wages, safe workshops, and inclusive hiring.</p>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-labelledby="timeline-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Timeline</span>
+            <h2 id="timeline-title" class="kdn-title">Milestones</h2>
+            <p class="kdn-subtitle">From underground drops to global collaborations, explore the chapters that shaped CEBASTIAN.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--2">
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">2017</span>
+                <h3 class="kdn-card__title">Debut Drop</h3>
+                <p class="kdn-card__text">Launched from a converted warehouse in Bushwick with 120 hand-numbered hoodies.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">2019</span>
+                <h3 class="kdn-card__title">Global Pop-Up Tour</h3>
+                <p class="kdn-card__text">Pop-ups in Seoul and Berlin introduced our holographic embroidery and interactive AR filters.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">2021</span>
+                <h3 class="kdn-card__title">Metaverse Capsule</h3>
+                <p class="kdn-card__text">Released the Ether Runner NFT sneakers with redeemable physical twins.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">2023</span>
+                <h3 class="kdn-card__title">Aurora Reign</h3>
+                <p class="kdn-card__text">The collection that put CEBASTIAN on the map for luminous techwear couture.</p>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="team-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">The Team</span>
+            <h2 id="team-title" class="kdn-title">Meet the Council</h2>
+            <p class="kdn-subtitle">An interdisciplinary squad of designers, technologists, and storytellers keep the CEBASTIAN realm evolving.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Sebastian Cruz</h3>
+                <p class="kdn-card__text">Founder &amp; Creative Director. Leads narrative world-building and oversees couture tailoring.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Eira Jónsdóttir</h3>
+                <p class="kdn-card__text">Head of Fabric Innovation. Develops thermoreactive textiles and sustainable alternatives.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Malik Rivera</h3>
+                <p class="kdn-card__text">Director of Digital Experience. Crafts interactive launches and AR filters for each drop.</p>
+            </article>
+        </div>
+    </div>
+</section>

--- a/wordpress/cebastian/additional-css.css
+++ b/wordpress/cebastian/additional-css.css
@@ -1,0 +1,812 @@
+/* Additional CSS for Kadence Theme – CEBASTIAN Co. */
+:root {
+    --primary: #00ffa7;
+    --primary-dark: #00cc85;
+    --secondary: #ffde76;
+    --accent: #4dcfff;
+    --dark: #0d0d0d;
+    --dark-alt: #1a1a1a;
+    --gray-900: #111827;
+    --gray-800: #1f2937;
+    --gray-700: #374151;
+    --gray-600: #4b5563;
+    --gray-500: #6b7280;
+    --gray-400: #9ca3af;
+    --gray-300: #d1d5db;
+    --gray-200: #e5e7eb;
+    --gray-100: #f3f4f6;
+    --white: #ffffff;
+    --featured-bg: #c6ccd4;
+    --radius-lg: 24px;
+    --transition-base: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body,
+.site,
+.site-content {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.6;
+    color: var(--gray-200);
+    background: radial-gradient(circle at 10% 20%, rgba(0, 255, 167, 0.08), transparent 55%),
+                radial-gradient(circle at 90% 10%, rgba(77, 207, 255, 0.08), transparent 55%),
+                linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);
+    overflow-x: hidden;
+}
+
+.site {
+    min-height: 100vh;
+}
+
+.site-main,
+.entry-content {
+    color: var(--gray-200);
+}
+
+:focus-visible {
+    outline: 3px solid var(--primary);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-link:focus {
+    position: fixed;
+    left: 1rem;
+    top: 1rem;
+    width: auto;
+    height: auto;
+    background: var(--white);
+    color: var(--dark);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    z-index: 2000;
+}
+
+.visually-hidden {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap;
+    border: 0;
+    padding: 0;
+    margin: -1px;
+}
+
+/* Header */
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(13, 13, 13, 0.95);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    transition: var(--transition-base);
+}
+
+.site-header .site-container,
+.site-header .header-container,
+.site-header .inside-header {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.site-branding .site-title,
+.site-branding .site-logo a,
+.site-branding .custom-logo-link,
+.site-branding .site-title a {
+    font-size: 1.75rem;
+    font-weight: 900;
+    background: linear-gradient(135deg, var(--primary), var(--secondary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-decoration: none;
+}
+
+.primary-navigation .menu,
+.primary-navigation ul {
+    list-style: none;
+    display: flex;
+    gap: 2rem;
+    margin: 0;
+    padding: 0;
+}
+
+.primary-navigation a,
+.header-navigation a,
+.site-header a {
+    color: var(--white);
+    font-weight: 500;
+    text-decoration: none;
+    position: relative;
+    transition: var(--transition-base);
+}
+
+.primary-navigation a::after,
+.header-navigation a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    width: 0;
+    height: 2px;
+    background: var(--primary);
+    transition: width 0.3s ease;
+}
+
+.primary-navigation a:hover,
+.primary-navigation a:focus-visible,
+.header-navigation a:hover,
+.header-navigation a:focus-visible {
+    color: var(--primary);
+}
+
+.primary-navigation a:hover::after,
+.primary-navigation a:focus-visible::after,
+.header-navigation a:hover::after,
+.header-navigation a:focus-visible::after {
+    width: 100%;
+}
+
+/* Header scroll state */
+body.has-scrolled .site-header {
+    background: rgba(13, 13, 13, 0.98);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+/* Footer */
+.site-footer {
+    background: linear-gradient(135deg, rgba(13, 13, 13, 0.95) 0%, rgba(20, 20, 20, 0.98) 100%);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.7);
+    padding: 4rem 2rem;
+}
+
+.site-footer .footer-widget-area {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    max-width: 1200px;
+    margin: 0 auto 2rem;
+}
+
+.site-footer .footer-bottom {
+    max-width: 1200px;
+    margin: 0 auto;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 2rem;
+    text-align: center;
+    font-size: 0.875rem;
+}
+
+.site-footer a {
+    color: var(--white);
+    text-decoration: none;
+    transition: var(--transition-base);
+}
+
+.site-footer a:hover {
+    color: var(--primary);
+}
+
+/* Global containers */
+.kdn-container,
+.site-content .entry-content > .alignwide,
+.site-content .entry-content > .alignfull,
+.site-content .entry-content > .wp-block-group.alignwide {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+}
+
+.kdn-section {
+    padding: clamp(3.5rem, 5vw, 6rem) 0;
+    position: relative;
+}
+
+.kdn-section--featured {
+    background:
+        radial-gradient(1200px 600px at 0% 0%, rgba(0, 255, 167, 0.1), transparent 60%),
+        radial-gradient(900px 500px at 100% 100%, rgba(255, 222, 118, 0.08), transparent 60%),
+        linear-gradient(180deg, #0b0b0b 0%, #121212 60%, #161616 100%);
+    overflow: hidden;
+}
+
+.kdn-section--featured::before {
+    content: "";
+    position: absolute;
+    inset: -10% -10% -10% -10%;
+    background:
+        radial-gradient(600px 300px at 10% 20%, rgba(77, 207, 255, 0.06), transparent 70%),
+        radial-gradient(500px 300px at 85% 80%, rgba(0, 255, 167, 0.05), transparent 70%);
+    pointer-events: none;
+}
+
+.kdn-section__header {
+    text-align: center;
+    margin-bottom: clamp(2.5rem, 6vw, 4rem);
+    position: relative;
+    z-index: 1;
+}
+
+.kdn-title {
+    font-size: clamp(2.5rem, 5vw, 3.75rem);
+    font-weight: 800;
+    margin-bottom: 0.75rem;
+    background: linear-gradient(135deg, var(--white) 0%, var(--primary) 50%, var(--secondary) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.kdn-section--featured .kdn-title {
+    background: linear-gradient(135deg, #ffffff 0%, #e5e7eb 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.kdn-subtitle {
+    font-size: clamp(1.125rem, 2.4vw, 1.35rem);
+    color: rgba(255, 255, 255, 0.75);
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.kdn-wave {
+    height: 100px;
+    overflow: hidden;
+    line-height: 0;
+}
+
+/* Hero */
+.kdn-hero {
+    min-height: 90vh;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    background: linear-gradient(135deg, rgba(13, 13, 13, 0.92) 0%, rgba(26, 26, 26, 0.85) 100%),
+                radial-gradient(circle at 20% 50%, rgba(0, 255, 167, 0.12) 0%, transparent 55%),
+                radial-gradient(circle at 80% 20%, rgba(255, 222, 118, 0.12) 0%, transparent 55%);
+    position: relative;
+    overflow: hidden;
+    border-radius: clamp(24px, 3vw, 48px);
+    margin: clamp(4rem, 8vw, 6rem) auto;
+    padding: clamp(3rem, 6vw, 5rem) 2rem;
+}
+
+.kdn-hero__particles,
+.kdn-hero__orb {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.kdn-hero__title {
+    font-size: clamp(3rem, 8vw, 6rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, var(--white) 0%, var(--primary) 50%, var(--secondary) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 1.25rem;
+}
+
+.kdn-hero__subtitle {
+    font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+    color: var(--gray-300);
+    margin-bottom: clamp(1.75rem, 3vw, 2.5rem);
+    font-weight: 300;
+}
+
+/* Buttons */
+.kdn-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.75rem 2rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1rem;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: var(--transition-base);
+    position: relative;
+    overflow: hidden;
+}
+
+.kdn-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+    transform: translateX(-100%);
+    transition: transform 0.5s ease;
+}
+
+.kdn-btn:hover::before,
+.kdn-btn:focus-visible::before {
+    transform: translateX(100%);
+}
+
+.kdn-btn--primary {
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--dark);
+    box-shadow: 0 20px 40px rgba(0, 255, 167, 0.2);
+}
+
+.kdn-btn--primary:hover,
+.kdn-btn--primary:focus-visible {
+    transform: translateY(-2px) scale(1.02);
+    box-shadow: 0 30px 60px rgba(0, 255, 167, 0.35);
+}
+
+.kdn-btn--outline {
+    border-color: var(--primary);
+    color: var(--primary);
+    background: transparent;
+}
+
+.kdn-btn--outline:hover,
+.kdn-btn--outline:focus-visible {
+    background: var(--primary);
+    color: var(--dark);
+    transform: translateY(-2px);
+}
+
+.kdn-btn--ghost {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--white);
+}
+
+/* Cards and grids */
+.kdn-product-grid,
+.kdn-grid {
+    display: grid;
+    gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.kdn-product-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.kdn-grid--2 {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.kdn-grid--3 {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.kdn-card {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-lg);
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    position: relative;
+    overflow: hidden;
+    transition: var(--transition-base);
+    color: var(--gray-200);
+}
+
+.kdn-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(0, 255, 167, 0.14), rgba(255, 222, 118, 0.14));
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+}
+
+.kdn-card:hover,
+.kdn-card:focus-within {
+    transform: translateY(-14px) scale(1.01);
+    box-shadow: 0 30px 70px rgba(0, 0, 0, 0.25);
+}
+
+.kdn-card:hover::before,
+.kdn-card:focus-within::before {
+    opacity: 1;
+}
+
+.kdn-card__title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+    color: var(--white);
+}
+
+.kdn-card__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.875rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.kdn-card__text {
+    color: var(--gray-300);
+    line-height: 1.7;
+}
+
+.kdn-card--value {
+    background: var(--white);
+    color: var(--gray-800);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.kdn-card--value .kdn-card__title {
+    color: var(--dark);
+}
+
+.kdn-card--value .kdn-card__text {
+    color: var(--gray-600);
+}
+
+.kdn-card__icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    margin: 0 auto 1.5rem;
+    font-size: 2rem;
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--dark);
+    box-shadow: 0 20px 40px rgba(0, 255, 167, 0.25);
+}
+
+.kdn-card__icon--secondary {
+    background: linear-gradient(135deg, var(--secondary), #e6c76a);
+    color: var(--dark);
+}
+
+.kdn-card__icon--accent {
+    background: linear-gradient(135deg, var(--accent), #3fb8e6);
+    color: var(--dark);
+}
+
+/* WooCommerce – product cards */
+.woocommerce ul.products,
+.woocommerce-page ul.products {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.woocommerce ul.products li.product,
+.woocommerce-page ul.products li.product {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem 1.5rem 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: var(--transition-base);
+    text-align: center;
+}
+
+.woocommerce ul.products li.product:hover {
+    transform: translateY(-16px);
+    box-shadow: 0 30px 70px rgba(0, 0, 0, 0.35);
+}
+
+.woocommerce ul.products li.product .woocommerce-loop-product__title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--white);
+}
+
+.woocommerce ul.products li.product .price {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: var(--primary);
+}
+
+.woocommerce a.button,
+.woocommerce button.button,
+.woocommerce input.button {
+    border-radius: 999px;
+    padding: 0.75rem 2rem;
+    border: none;
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--dark);
+    font-weight: 600;
+    transition: var(--transition-base);
+}
+
+.woocommerce a.button:hover,
+.woocommerce button.button:hover,
+.woocommerce input.button:hover {
+    filter: brightness(1.08);
+    transform: translateY(-3px);
+}
+
+.woocommerce nav.woocommerce-pagination ul {
+    border: none;
+}
+
+.woocommerce nav.woocommerce-pagination ul li {
+    border: none;
+}
+
+.woocommerce nav.woocommerce-pagination ul li a,
+.woocommerce nav.woocommerce-pagination ul li span {
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--white);
+    padding: 0.5rem 1rem;
+    margin: 0 0.25rem;
+}
+
+.woocommerce nav.woocommerce-pagination ul li span.current {
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--dark);
+}
+
+/* WooCommerce My Account */
+.woocommerce-account .woocommerce-MyAccount-navigation {
+    background: rgba(255, 255, 255, 0.06);
+    padding: 2rem;
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul {
+    display: grid;
+    gap: 0.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 999px;
+    text-decoration: none;
+    color: var(--gray-200);
+    background: rgba(255, 255, 255, 0.05);
+    transition: var(--transition-base);
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li.is-active a,
+.woocommerce-account .woocommerce-MyAccount-navigation li a:hover {
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--dark);
+}
+
+.woocommerce-account .woocommerce-MyAccount-content {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: clamp(2rem, 3vw, 3rem);
+}
+
+.woocommerce-account .woocommerce-MyAccount-content a {
+    color: var(--primary);
+}
+
+/* Newsletter */
+.kdn-newsletter {
+    background: linear-gradient(135deg, var(--dark) 0%, var(--dark-alt) 100%);
+    border-radius: clamp(24px, 3vw, 40px);
+    padding: clamp(2.5rem, 4vw, 3.5rem);
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.kdn-newsletter::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 30% 70%, rgba(0, 255, 167, 0.1), transparent 55%),
+                radial-gradient(circle at 70% 30%, rgba(255, 222, 118, 0.1), transparent 55%);
+}
+
+.kdn-newsletter__inner {
+    position: relative;
+    z-index: 1;
+}
+
+.kdn-newsletter__form {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    max-width: 420px;
+    margin: 0 auto;
+}
+
+.kdn-newsletter__form input[type="email"] {
+    flex: 1;
+    padding: 1rem 1.5rem;
+    border-radius: 999px;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--white);
+    transition: var(--transition-base);
+}
+
+.kdn-newsletter__form input[type="email"]:focus {
+    outline: 3px solid var(--primary);
+    outline-offset: 3px;
+    border-color: var(--primary);
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.kdn-newsletter__form input::placeholder {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+/* Utility */
+.kdn-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.kdn-stat {
+    text-align: center;
+    padding: clamp(1.5rem, 2.5vw, 2.5rem);
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.kdn-stat__value {
+    font-size: clamp(2.25rem, 4vw, 3rem);
+    font-weight: 800;
+    color: var(--primary);
+}
+
+.kdn-stat__label {
+    color: var(--gray-400);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+/* Animations */
+.kdn-animate {
+    opacity: 0;
+    transform: translateY(50px);
+    transition: opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+                transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.kdn-animate.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Media queries */
+@media (max-width: 1024px) {
+    .site-header .site-container,
+    .site-header .inside-header {
+        padding: 0.85rem 1.5rem;
+    }
+
+    .primary-navigation .menu {
+        gap: 1.25rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .kdn-container,
+    .site-content .entry-content > .alignwide,
+    .site-content .entry-content > .alignfull {
+        padding: 0 1.25rem;
+    }
+
+    .kdn-hero {
+        margin: 3rem 0;
+        border-radius: 24px;
+    }
+
+    .kdn-newsletter__form {
+        flex-direction: column;
+    }
+
+    .kdn-newsletter__form input[type="email"],
+    .kdn-newsletter__form .kdn-btn {
+        width: 100%;
+    }
+
+    .woocommerce-account .woocommerce-MyAccount-navigation {
+        margin-bottom: 2rem;
+    }
+
+    .site-footer {
+        padding: 3rem 1.5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+/* Shortcode placeholders for editors */
+.woocommerce-shortcode {
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+    padding: 1.5rem;
+    border-radius: var(--radius-lg);
+}
+
+.kdn-contact-form input,
+.kdn-contact-form select,
+.kdn-contact-form textarea {
+    width: 100%;
+    padding: 0.85rem 1.25rem;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--white);
+    font-size: 1rem;
+    transition: var(--transition-base);
+}
+
+.kdn-contact-form input:focus,
+.kdn-contact-form select:focus,
+.kdn-contact-form textarea:focus {
+    outline: 3px solid var(--primary);
+    outline-offset: 3px;
+    border-color: var(--primary);
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.kdn-contact-form textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.kdn-contact-form select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, var(--primary) 50%),
+                      linear-gradient(135deg, var(--primary) 50%, transparent 50%);
+    background-position: calc(100% - 20px) calc(1.2em), calc(100% - 15px) calc(1.2em);
+    background-size: 6px 6px;
+    background-repeat: no-repeat;
+}
+
+.kdn-btn.is-success {
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+    color: var(--dark);
+}

--- a/wordpress/cebastian/contact.html
+++ b/wordpress/cebastian/contact.html
@@ -1,0 +1,98 @@
+<!-- CEBASTIAN Co. – Contact Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="contact-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">Contact</p>
+            <h1 id="contact-title" class="kdn-title">Reach the CEBASTIAN Council</h1>
+            <p class="kdn-subtitle">Whether you have a question about sizing, shipping, styling, or storytelling, our team is ready to help. Select the portal that fits your mission.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Customer Support</h2>
+                <p class="kdn-card__text">Need assistance with an order, return, or warranty? Our concierge responds within 24 hours.</p>
+                <p class="kdn-card__text"><strong>Email:</strong> <a href="mailto:support@cebastianco.com">support@cebastianco.com</a></p>
+                <p class="kdn-card__text"><strong>Text:</strong> <a href="sms:+13475551234">+1 (347) 555-1234</a></p>
+            </article>
+            <article class="kdn-card kdn-animate" id="press">
+                <h2 class="kdn-card__title">Press &amp; Media</h2>
+                <p class="kdn-card__text">Request high-resolution assets, interviews, or collaboration briefs.</p>
+                <p class="kdn-card__text"><strong>Email:</strong> <a href="mailto:press@cebastianco.com">press@cebastianco.com</a></p>
+                <a class="kdn-btn kdn-btn--outline" href="/about/#community">View Collaborations</a>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Wholesale &amp; Stockists</h2>
+                <p class="kdn-card__text">Interested in carrying CEBASTIAN? Submit your showroom details for access to our lookbook and line sheet.</p>
+                <p class="kdn-card__text"><strong>Email:</strong> <a href="mailto:wholesale@cebastianco.com">wholesale@cebastianco.com</a></p>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-labelledby="form-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-animate">
+                <h2 id="form-title" class="kdn-title">Send a Message</h2>
+                <p class="kdn-subtitle">Complete the form and select your request type. Our support queue routes directly to the specialist best suited to assist.</p>
+                <ul class="kdn-card__text" style="margin-top:1.5rem; list-style:none; padding:0; display:grid; gap:0.75rem;">
+                    <li>• Questions about fit, fabric, or care instructions.</li>
+                    <li>• Order modifications within 2 hours of purchase.</li>
+                    <li>• Styling sessions for upcoming events.</li>
+                </ul>
+            </div>
+            <div class="kdn-card kdn-animate" style="background:rgba(255,255,255,0.08);">
+                <form class="kdn-contact-form" data-form-type="contact" style="display:grid; gap:1rem;">
+                    <div>
+                        <label for="contact-name" class="visually-hidden">Full Name</label>
+                        <input id="contact-name" type="text" name="name" placeholder="Full Name" required>
+                    </div>
+                    <div>
+                        <label for="contact-email" class="visually-hidden">Email Address</label>
+                        <input id="contact-email" type="email" name="email" placeholder="Email Address" required>
+                    </div>
+                    <div>
+                        <label for="contact-topic" class="visually-hidden">Topic</label>
+                        <select id="contact-topic" name="topic" required>
+                            <option value="" disabled selected>Select a topic</option>
+                            <option value="order">Order Support</option>
+                            <option value="styling">Styling Session</option>
+                            <option value="press">Press Inquiry</option>
+                            <option value="wholesale">Wholesale</option>
+                            <option value="other">Other</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="contact-message" class="visually-hidden">Message</label>
+                        <textarea id="contact-message" name="message" rows="5" placeholder="How can we help?" required></textarea>
+                    </div>
+                    <button type="submit" class="kdn-btn kdn-btn--primary">Submit Request</button>
+                    <span class="visually-hidden" data-newsletter-status></span>
+                </form>
+                <p class="kdn-card__text" style="margin-top:1rem;">Prefer direct email? Write to <a href="mailto:hello@cebastianco.com">hello@cebastianco.com</a>.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="visit-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Studio Visits</span>
+            <h2 id="visit-title" class="kdn-title">Visit the Sanctuary</h2>
+            <p class="kdn-subtitle">Experience fabrics in person, preview upcoming drops, and customize fits in our Brooklyn studio. Visits are by appointment only.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Location</h3>
+                <p class="kdn-card__text">109 Mythic Avenue, Suite 7F<br>Brooklyn, NY 11221</p>
+                <p class="kdn-card__text"><strong>Hours:</strong> Thu – Sun, 11:00 AM – 7:00 PM EST</p>
+                <a class="kdn-btn kdn-btn--outline" href="https://maps.google.com/?q=109+Mythic+Avenue+Brooklyn+NY" target="_blank" rel="noopener">Open in Maps</a>
+            </div>
+            <div class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Virtual Styling</h3>
+                <p class="kdn-card__text">Book a 30-minute holographic styling session. We beam garments onto your avatar using volumetric capture.</p>
+                <a class="kdn-btn kdn-btn--primary" href="/shop/">Book a Session</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/wordpress/cebastian/home.html
+++ b/wordpress/cebastian/home.html
@@ -1,0 +1,157 @@
+<!-- CEBASTIAN Co. – Home Page Content (Kadence HTML Block) -->
+<main id="main" class="kdn-main" role="main">
+    <section id="hero" class="kdn-hero kdn-animate">
+        <div class="kdn-container">
+            <p class="kdn-pill" aria-label="Luxury streetwear tagline">Myth-Forged Streetwear</p>
+            <h1 class="kdn-hero__title">CEBASTIAN</h1>
+            <p class="kdn-hero__subtitle">Luxury streetwear with a mythical edge. Discover capsule collections, handcrafted drops, and timeless silhouettes inspired by legends.</p>
+            <div class="kdn-hero__cta" style="display:flex; gap:1rem; justify-content:center; flex-wrap:wrap;">
+                <a class="kdn-btn kdn-btn--primary" href="/shop/" aria-label="Explore the CEBASTIAN shop">Explore Collection
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M5 12h14M12 5l7 7-7 7"></path>
+                    </svg>
+                </a>
+                <a class="kdn-btn kdn-btn--outline" href="/lookbook/" aria-label="View the CEBASTIAN lookbook">View Lookbook</a>
+            </div>
+        </div>
+    </section>
+
+    <div class="kdn-wave" aria-hidden="true">
+        <svg viewBox="0 0 1440 100" fill="none" xmlns="http://www.w3.org/2000/svg" role="presentation">
+            <path d="M0 50 C240 20 480 80 720 50 C960 20 1200 80 1440 50 V0 H0 Z" fill="#0d0d0d"></path>
+            <path d="M0 100 H1440 V50 C1200 80 960 20 720 50 C480 80 240 20 0 50 V100 Z" fill="#c6ccd4"></path>
+        </svg>
+    </div>
+
+    <section id="featured" class="kdn-section kdn-section--featured">
+        <div class="kdn-container">
+            <header class="kdn-section__header kdn-animate">
+                <p class="kdn-pill">Fresh Drops</p>
+                <h2 class="kdn-title">Featured Collection</h2>
+                <p class="kdn-subtitle">Hand-picked garments that embody celestial grit—constructed with premium materials, limited-run finishes, and sustainable dyes.</p>
+            </header>
+
+            <div class="kdn-animate">
+                <!-- WooCommerce Shortcode -->
+                <div class="woocommerce-shortcode">[products limit="8" columns="4" orderby="date" order="DESC" visibility="visible"]</div>
+            </div>
+
+            <div style="text-align:center; margin-top:2.5rem;" class="kdn-animate">
+                <a class="kdn-btn kdn-btn--outline" href="/shop/">Shop the Full Catalog</a>
+            </div>
+        </div>
+    </section>
+
+    <section id="ethos" class="kdn-section">
+        <div class="kdn-container">
+            <div class="kdn-section__header kdn-animate">
+                <p class="kdn-pill">Brand Pillars</p>
+                <h2 class="kdn-title">Crafted With Purpose</h2>
+                <p class="kdn-subtitle">We translate epic stories into wearable art. Every CEBASTIAN piece is engineered for future legends, balancing couture techniques with everyday comfort.</p>
+            </div>
+
+            <div class="kdn-grid kdn-grid--3">
+                <article class="kdn-card kdn-card--value kdn-animate">
+                    <div class="kdn-card__icon" aria-hidden="true">⚡️</div>
+                    <h3 class="kdn-card__title">Signature Materials</h3>
+                    <p class="kdn-card__text">Ultra-premium fabrics sourced from responsible mills, featuring heavyweight French terry, buttery vegan leather, and thermoregulating weaves.</p>
+                </article>
+                <article class="kdn-card kdn-card--value kdn-animate">
+                    <div class="kdn-card__icon kdn-card__icon--secondary" aria-hidden="true">🛡️</div>
+                    <h3 class="kdn-card__title">Limited Legends</h3>
+                    <p class="kdn-card__text">Micro drops of 150 units or less, numbered for authenticity. Once the run sells through, the design is retired to protect rarity.</p>
+                </article>
+                <article class="kdn-card kdn-card--value kdn-animate">
+                    <div class="kdn-card__icon kdn-card__icon--accent" aria-hidden="true">🌱</div>
+                    <h3 class="kdn-card__title">Future-Forward</h3>
+                    <p class="kdn-card__text">Recycled packaging, low-impact dyes, and carbon-neutral logistics—we honor the realm we draw inspiration from.</p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section id="lookbook" class="kdn-section kdn-section--featured">
+        <div class="kdn-container">
+            <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+                <div class="kdn-animate">
+                    <span class="kdn-pill">Seasonal Narrative</span>
+                    <h2 class="kdn-title">Lookbook: Aurora Reign</h2>
+                    <p class="kdn-subtitle">Drift through nebula-drenched cityscapes with iridescent puffers, reflective denim, and embroidered sigils that glow after dark. Styled in partnership with neon artist Kyra Sol.</p>
+                    <ul style="margin-top:1.5rem; list-style:none; padding:0; display:grid; gap:0.75rem;">
+                        <li>• Modular layers engineered for day-to-night transitions.</li>
+                        <li>• Luminescent threads powered by motion-activated fibers.</li>
+                        <li>• Capsule accessories: holo-sling bags, myth-marked caps, and rune-laced boots.</li>
+                    </ul>
+                    <div style="margin-top:2rem; display:flex; gap:1rem; flex-wrap:wrap;">
+                        <a class="kdn-btn kdn-btn--primary" href="/lookbook/">See the Editorial</a>
+                        <a class="kdn-btn kdn-btn--ghost" href="/shop/" aria-label="Shop the Aurora Reign collection">Shop the Capsule</a>
+                    </div>
+                </div>
+                <div class="kdn-animate" style="position:relative;">
+                    <div class="kdn-card" style="background:rgba(255,255,255,0.08);">
+                        <h3 class="kdn-card__title">Behind the Lens</h3>
+                        <p class="kdn-card__text">Photographed in Reykjavík at blue hour, our crew battled arctic gusts to harness the aurora. The collection reflects resilience—thermal linings paired with breathable mesh keep the fit responsive.</p>
+                        <div class="kdn-grid kdn-grid--2" style="margin-top:1.5rem;">
+                            <div class="kdn-stat">
+                                <p class="kdn-stat__value">12</p>
+                                <p class="kdn-stat__label">Signature Looks</p>
+                            </div>
+                            <div class="kdn-stat">
+                                <p class="kdn-stat__value">4</p>
+                                <p class="kdn-stat__label">Collaborators</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="stories" class="kdn-section">
+        <div class="kdn-container">
+            <div class="kdn-section__header kdn-animate">
+                <span class="kdn-pill">Journal</span>
+                <h2 class="kdn-title">Mythic Dispatch</h2>
+                <p class="kdn-subtitle">Deep dives into the craftsmanship, origin myths, and community voices shaping the CEBASTIAN universe.</p>
+            </div>
+            <div class="kdn-grid kdn-grid--3">
+                <article class="kdn-card kdn-animate">
+                    <span class="kdn-card__eyebrow">Studio Notes</span>
+                    <h3 class="kdn-card__title">Designing Armor for the Everyday</h3>
+                    <p class="kdn-card__text">From sketchbook to sewing floor: how we integrate hidden pockets, reinforced seams, and contrast textures to create garments ready for urban quests.</p>
+                    <a class="kdn-btn kdn-btn--ghost" href="/about/#craft" aria-label="Read about our design approach">Read More</a>
+                </article>
+                <article class="kdn-card kdn-animate">
+                    <span class="kdn-card__eyebrow">Community</span>
+                    <h3 class="kdn-card__title">Legends Spotlight: The Vanguard</h3>
+                    <p class="kdn-card__text">Meet the collective of dancers, gamers, and producers who co-create our drops. Each release pairs with immersive AR experiences.</p>
+                    <a class="kdn-btn kdn-btn--ghost" href="/about/#community" aria-label="Meet the Vanguard community">Meet the Vanguard</a>
+                </article>
+                <article class="kdn-card kdn-animate">
+                    <span class="kdn-card__eyebrow">Sustainability</span>
+                    <h3 class="kdn-card__title">Our Pledge to the Realm</h3>
+                    <p class="kdn-card__text">We offset emissions through reforestation in Iceland and invest in textile recycling programs that fuel our future fabrics.</p>
+                    <a class="kdn-btn kdn-btn--ghost" href="/about/#sustainability" aria-label="Learn about sustainability">View Commitments</a>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section id="newsletter" class="kdn-section">
+        <div class="kdn-container">
+            <div class="kdn-newsletter kdn-animate">
+                <div class="kdn-newsletter__inner">
+                    <h2 class="kdn-title" style="font-size:clamp(2rem,4vw,3rem);">Stay in the Loop</h2>
+                    <p class="kdn-subtitle">Gain first access to limited drops, priority invites to digital events, and secret lore from the studio.</p>
+                    <form class="kdn-newsletter__form" data-form-type="newsletter">
+                        <label for="newsletter-email-home" class="visually-hidden">Email address</label>
+                        <input id="newsletter-email-home" type="email" name="email" placeholder="Enter your email" required>
+                        <button type="submit" class="kdn-btn kdn-btn--primary">Subscribe</button>
+                        <span class="visually-hidden" data-newsletter-status></span>
+                    </form>
+                    <p style="margin-top:1rem; font-size:0.875rem; color:rgba(255,255,255,0.7);">No spam. Unsubscribe any time.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>

--- a/wordpress/cebastian/lookbook.html
+++ b/wordpress/cebastian/lookbook.html
@@ -1,0 +1,105 @@
+<!-- CEBASTIAN Co. – Lookbook Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="lookbook-hero-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">Lookbook</p>
+            <h1 id="lookbook-hero-title" class="kdn-title">Aurora Reign Editorial</h1>
+            <p class="kdn-subtitle">Shot amidst Icelandic lava fields, Aurora Reign fuses luminescent pigments with thermal armor. Scroll to explore hero looks, styling cues, and behind-the-scenes lore.</p>
+        </header>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-label="Lookbook highlight gallery">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--3">
+            <figure class="kdn-card kdn-animate" role="group" aria-labelledby="look-one">
+                <span class="kdn-card__eyebrow" id="look-one">Look 01</span>
+                <h2 class="kdn-card__title">Starlight Nomad</h2>
+                <p class="kdn-card__text">Iridescent parka with adaptive insulation, paired with reflective cargo joggers and rune-laced boots.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="/shop/?filter=aura%3Dneon">Shop Aura: Neon</a>
+            </figure>
+            <figure class="kdn-card kdn-animate" role="group" aria-labelledby="look-two">
+                <span class="kdn-card__eyebrow" id="look-two">Look 02</span>
+                <h2 class="kdn-card__title">Glacial Empress</h2>
+                <p class="kdn-card__text">Structured cape with translucent scales, layered over frost-tone bodysuit and luminous gloves.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="/shop/?filter=rarity%3Dlimited">Shop Limited Drops</a>
+            </figure>
+            <figure class="kdn-card kdn-animate" role="group" aria-labelledby="look-three">
+                <span class="kdn-card__eyebrow" id="look-three">Look 03</span>
+                <h2 class="kdn-card__title">Eclipse Runner</h2>
+                <p class="kdn-card__text">Shadow-layered bomber with aurora piping, matched with kinetic leggings and stealth gaiters.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="/shop/?filter=aura%3Declipse">Shop Aura: Eclipse</a>
+            </figure>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="styling-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-animate">
+                <span class="kdn-pill">Styling Notes</span>
+                <h2 id="styling-title" class="kdn-title">How to Wear the Aurora Reign Capsule</h2>
+                <p class="kdn-subtitle">Balance luminous garments with matte layers, and lean into modular accessories to adapt to shifting climates.</p>
+                <ul class="kdn-card__text" style="margin-top:1.5rem; list-style:none; padding:0; display:grid; gap:0.75rem;">
+                    <li>• Layer reflective outerwear over tonal base layers to highlight silhouettes.</li>
+                    <li>• Pair rune-stitched belts with relaxed trousers to cinch shapes without compromising comfort.</li>
+                    <li>• Incorporate holo-foil accessories for nightlife transitions.</li>
+                </ul>
+            </div>
+            <div class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Palette Breakdown</h3>
+                <p class="kdn-card__text">Aurora green, obsidian black, frost white, and cosmic gold interplay to mimic the northern lights. Each look includes a dynamic component that shifts under UV light.</p>
+                <div class="kdn-grid kdn-grid--2" style="margin-top:1.5rem;">
+                    <div class="kdn-stat">
+                        <p class="kdn-stat__value">80%</p>
+                        <p class="kdn-stat__label">Recycled Fibers</p>
+                    </div>
+                    <div class="kdn-stat">
+                        <p class="kdn-stat__value">12</p>
+                        <p class="kdn-stat__label">Signature Pieces</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-labelledby="behind-scenes-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-card kdn-animate" style="background:rgba(255,255,255,0.08);">
+                <h2 id="behind-scenes-title" class="kdn-card__title">Behind the Scenes</h2>
+                <p class="kdn-card__text">We trekked across volcanic terrain at sunrise to capture the aurora’s edge. Motion-activated LEDs were synchronized with drone choreography, illuminating garments as the models moved.</p>
+                <p class="kdn-card__text">Photographer Kyra Sol and cinematographer Daeon Li used long-exposure techniques to render trails of light around each silhouette.</p>
+                <a class="kdn-btn kdn-btn--outline" href="/about/#timeline">Explore Our Journey</a>
+            </div>
+            <div class="kdn-animate">
+                <div class="kdn-card">
+                    <h3 class="kdn-card__title">Soundtrack</h3>
+                    <p class="kdn-card__text">A collaborative score produced by Nova Rook, featuring ambient synths and field recordings from glacier caves.</p>
+                    <a class="kdn-btn kdn-btn--ghost" href="https://open.spotify.com" target="_blank" rel="noopener">Stream the Playlist</a>
+                </div>
+                <div class="kdn-card kdn-animate" style="margin-top:1.5rem;">
+                    <h3 class="kdn-card__title">Interactive Experience</h3>
+                    <p class="kdn-card__text">Scan the NFC patch on each garment to unlock AR portals, exclusive filters, and lore chapters.</p>
+                    <a class="kdn-btn kdn-btn--primary" href="/shop/">Shop Aurora Reign</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="lookbook-products-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Shop the Editorial</span>
+            <h2 id="lookbook-products-title" class="kdn-title">Featured Pieces</h2>
+            <p class="kdn-subtitle">Add these Aurora Reign essentials to your arsenal.</p>
+        </header>
+        <div class="kdn-animate">
+            <!-- WooCommerce Shortcode -->
+            <div class="woocommerce-shortcode">[featured_products limit="6" columns="3"]</div>
+        </div>
+    </div>
+</section>

--- a/wordpress/cebastian/my-account.html
+++ b/wordpress/cebastian/my-account.html
@@ -1,0 +1,97 @@
+<!-- CEBASTIAN Co. – My Account Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="account-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">Member Portal</p>
+            <h1 id="account-title" class="kdn-title">Welcome to the CEBASTIAN Guild</h1>
+            <p class="kdn-subtitle">Manage orders, update profile details, redeem loyalty perks, and access exclusive drops from your personalized dashboard.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Track Your Orders</h2>
+                <p class="kdn-card__text">Monitor current shipments, download invoices, and initiate returns with ease.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="#dashboard-orders">View Orders</a>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Manage Profile</h2>
+                <p class="kdn-card__text">Update addresses, payment methods, and wardrobe preferences to tailor future drops.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="#dashboard-details">Edit Details</a>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h2 class="kdn-card__title">Loyalty Rewards</h2>
+                <p class="kdn-card__text">Earn points for every purchase. Unlock early access and exclusive experiences.</p>
+                <a class="kdn-btn kdn-btn--ghost" href="#dashboard-rewards">Check Rewards</a>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section id="dashboard" class="kdn-section kdn-section--featured" aria-labelledby="dashboard-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Dashboard</span>
+            <h2 id="dashboard-title" class="kdn-title">Your Control Center</h2>
+            <p class="kdn-subtitle">Use the navigation on the left to switch between dashboard panels. Actions below pull directly from WooCommerce so data is always current.</p>
+        </header>
+        <div class="kdn-animate">
+            <!-- WooCommerce Shortcode -->
+            <div class="woocommerce-shortcode">[woocommerce_my_account]</div>
+        </div>
+    </div>
+</section>
+
+<section id="dashboard-rewards" class="kdn-section" aria-labelledby="rewards-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-animate">
+                <span class="kdn-pill">Loyalty Program</span>
+                <h2 id="rewards-title" class="kdn-title">The Legend Tier System</h2>
+                <p class="kdn-subtitle">Collect points every time you suit up in CEBASTIAN. Redeem them for exclusive experiences and secret drops.</p>
+                <ul class="kdn-card__text" style="margin-top:1.5rem; list-style:none; padding:0; display:grid; gap:0.75rem;">
+                    <li>• 1 point per $1 spent. 500 points unlocks free express shipping for a year.</li>
+                    <li>• 750 points grants access to quarterly mystery drops.</li>
+                    <li>• 1200 points elevates you to the Aurora Circle with custom tailoring sessions.</li>
+                </ul>
+            </div>
+            <div class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Upcoming Member Events</h3>
+                <ul class="kdn-card__text" style="list-style:none; padding:0; display:grid; gap:0.75rem;">
+                    <li><strong>July 18:</strong> Virtual tour of the Aurora Reign atelier.</li>
+                    <li><strong>August 05:</strong> Community design workshop hosted in Brooklyn.</li>
+                    <li><strong>September 09:</strong> Sneak peek of the Equinox Echo capsule.</li>
+                </ul>
+                <a class="kdn-btn kdn-btn--outline" href="/contact/">RSVP with Concierge</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="dashboard-orders" class="kdn-section kdn-section--featured" aria-labelledby="orders-help-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-card kdn-animate" style="background:rgba(255,255,255,0.08);">
+                <h2 id="orders-help-title" class="kdn-card__title">Need Help with an Order?</h2>
+                <p class="kdn-card__text">Our support team can expedite changes within two hours of purchase. Use the customer support portal for urgent requests.</p>
+                <a class="kdn-btn kdn-btn--primary" href="mailto:support@cebastianco.com">Email Support</a>
+            </div>
+            <div class="kdn-animate">
+                <div class="kdn-card">
+                    <h3 class="kdn-card__title">Quick Links</h3>
+                    <ul class="kdn-card__text" style="list-style:none; padding:0; display:grid; gap:0.75rem;">
+                        <li><a href="/contact/">Request a return label</a></li>
+                        <li><a href="/shop/">Browse restocks</a></li>
+                        <li><a href="/about/#sustainability">Review care &amp; repair program</a></li>
+                    </ul>
+                </div>
+                <div class="kdn-card kdn-animate" id="dashboard-details" style="margin-top:1.5rem;">
+                    <h3 class="kdn-card__title">Profile Checklist</h3>
+                    <ul class="kdn-card__text" style="list-style:none; padding:0; display:grid; gap:0.75rem;">
+                        <li>☑ Add a default shipping address.</li>
+                        <li>☑ Save your preferred payment method.</li>
+                        <li>☑ Select your fit preference for tailored recommendations.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/wordpress/cebastian/newsletter.html
+++ b/wordpress/cebastian/newsletter.html
@@ -1,0 +1,78 @@
+<!-- CEBASTIAN Co. – Newsletter Landing Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="newsletter-hero-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">Newsletter</p>
+            <h1 id="newsletter-hero-title" class="kdn-title">Join the Mythic Dispatch</h1>
+            <p class="kdn-subtitle">Subscribers receive early access to drops, archive reissues, secret lore, and invitations to digital quests. It’s the only portal to secure rare CEBASTIAN intel.</p>
+        </header>
+        <div class="kdn-newsletter kdn-animate">
+            <div class="kdn-newsletter__inner">
+                <h2 class="kdn-title" style="font-size:clamp(2rem,4vw,3rem);">Summon the Signal</h2>
+                <p class="kdn-subtitle">Enter your email to activate access. You’ll also unlock a downloadable care guide for maintaining mythic garments.</p>
+                <form class="kdn-newsletter__form" data-form-type="newsletter">
+                    <label for="newsletter-email-landing" class="visually-hidden">Email address</label>
+                    <input id="newsletter-email-landing" type="email" name="email" placeholder="Email Address" required>
+                    <button type="submit" class="kdn-btn kdn-btn--primary">Subscribe</button>
+                    <span class="visually-hidden" data-newsletter-status></span>
+                </form>
+                <p style="margin-top:1rem; font-size:0.875rem; color:rgba(255,255,255,0.75);">We respect your inbox. Expect 2-3 dispatches per month.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-labelledby="newsletter-perks-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Perks</span>
+            <h2 id="newsletter-perks-title" class="kdn-title">What You’ll Receive</h2>
+            <p class="kdn-subtitle">Every newsletter drop unlocks exclusive experiences and tools to level up your wardrobe.</p>
+        </header>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Early Access</h3>
+                <p class="kdn-card__text">Reserve pieces 24 hours before they go public. Hot drops often sell out during the presale window.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Lore Files</h3>
+                <p class="kdn-card__text">Downloadable zines, world-building chapters, and soundtrack playlists with every major release.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Concierge Offers</h3>
+                <p class="kdn-card__text">Receive invite-only styling sessions, studio tours, and archive sales.</p>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="newsletter-faq-title">
+    <div class="kdn-container">
+        <div class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">FAQ</span>
+            <h2 id="newsletter-faq-title" class="kdn-title">Dispatch Questions</h2>
+            <p class="kdn-subtitle">Here’s what subscribers ask most before stepping into the realm.</p>
+        </div>
+        <div class="kdn-grid kdn-grid--2">
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">How often will you email me?</h3>
+                <p class="kdn-card__text">We send two standard newsletters per month, plus special alerts for product launches and community quests.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Can I unsubscribe?</h3>
+                <p class="kdn-card__text">Absolutely. Every dispatch includes an unsubscribe link and a preferences center to control the intel you receive.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">Do subscribers get discounts?</h3>
+                <p class="kdn-card__text">Members receive seasonal codes, loyalty multipliers, and invitations to exclusive archive sales.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <h3 class="kdn-card__title">What if I miss a drop?</h3>
+                <p class="kdn-card__text">Dispatch archives remain accessible for 30 days so you can revisit lookbooks, playlists, and redemption codes.</p>
+            </article>
+        </div>
+        <div style="text-align:center; margin-top:2.5rem;" class="kdn-animate">
+            <a class="kdn-btn kdn-btn--primary" href="#newsletter-hero-title">Subscribe Now</a>
+        </div>
+    </div>
+</section>

--- a/wordpress/cebastian/scripts.js
+++ b/wordpress/cebastian/scripts.js
@@ -1,0 +1,110 @@
+/* Kadence Custom JS for CEBASTIAN Co. */
+(function () {
+    const body = document.body;
+
+    const onScroll = () => {
+        if (window.scrollY > 60) {
+            body.classList.add('has-scrolled');
+        } else {
+            body.classList.remove('has-scrolled');
+        }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+
+    const animateEls = document.querySelectorAll('.kdn-animate');
+    if ('IntersectionObserver' in window && animateEls.length) {
+        const observer = new IntersectionObserver((entries, obs) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    obs.unobserve(entry.target);
+                }
+            });
+        }, {
+            threshold: 0.15,
+            rootMargin: '0px 0px -60px 0px'
+        });
+
+        animateEls.forEach((el) => observer.observe(el));
+    } else {
+        animateEls.forEach((el) => el.classList.add('is-visible'));
+    }
+
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+        anchor.addEventListener('click', (event) => {
+            const href = anchor.getAttribute('href');
+            if (!href || href === '#') return;
+            const target = document.querySelector(href);
+            if (target) {
+                event.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+
+    const newsletterForms = document.querySelectorAll('.kdn-newsletter__form');
+    newsletterForms.forEach((form) => {
+        const submitBtn = form.querySelector('button, input[type="submit"]');
+        const status = form.querySelector('[data-newsletter-status]');
+        form.addEventListener('submit', (event) => {
+            if (!submitBtn) return;
+            event.preventDefault();
+            const emailField = form.querySelector('input[type="email"]');
+            const originalLabel = submitBtn.textContent;
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Subscribing…';
+
+            setTimeout(() => {
+                submitBtn.textContent = 'Subscribed!';
+                submitBtn.setAttribute('aria-live', 'polite');
+                submitBtn.classList.add('is-success');
+                if (status) {
+                    status.textContent = `Subscribed with ${emailField.value}`;
+                }
+
+                setTimeout(() => {
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = originalLabel;
+                    submitBtn.classList.remove('is-success');
+                    form.reset();
+                    if (status) {
+                        status.textContent = '';
+                    }
+                }, 2200);
+            }, 1200);
+        });
+    });
+
+    const contactForms = document.querySelectorAll('.kdn-contact-form');
+    contactForms.forEach((form) => {
+        const submitBtn = form.querySelector('button, input[type="submit"]');
+        const status = form.querySelector('[data-newsletter-status]');
+        form.addEventListener('submit', (event) => {
+            if (!submitBtn) return;
+            event.preventDefault();
+            const originalText = submitBtn.textContent;
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Sending…';
+
+            setTimeout(() => {
+                submitBtn.textContent = 'Message Sent';
+                submitBtn.classList.add('is-success');
+                if (status) {
+                    status.textContent = 'Thank you! Our concierge will respond within 24 hours.';
+                }
+
+                setTimeout(() => {
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = originalText;
+                    submitBtn.classList.remove('is-success');
+                    form.reset();
+                    if (status) {
+                        status.textContent = '';
+                    }
+                }, 2400);
+            }, 1400);
+        });
+    });
+})();

--- a/wordpress/cebastian/shop.html
+++ b/wordpress/cebastian/shop.html
@@ -1,0 +1,123 @@
+<!-- CEBASTIAN Co. – Shop Page Content (Kadence HTML Block) -->
+<section class="kdn-section" aria-labelledby="shop-hero-title">
+    <div class="kdn-container">
+        <div class="kdn-grid kdn-grid--2" style="align-items:center;">
+            <div class="kdn-animate">
+                <p class="kdn-pill">Shop</p>
+                <h1 id="shop-hero-title" class="kdn-title" style="font-size:clamp(2.75rem,6vw,4rem);">Discover Your Next Legend</h1>
+                <p class="kdn-subtitle">Browse celestial streetwear engineered for performance and presence. Sort by drop, category, or vibe, then assemble your own pantheon.</p>
+                <div style="margin-top:2rem; display:flex; gap:1rem; flex-wrap:wrap;">
+                    <a class="kdn-btn kdn-btn--primary" href="#catalog">Jump to Catalog</a>
+                    <a class="kdn-btn kdn-btn--ghost" href="/contact/" aria-label="Connect with styling concierge">Styling Concierge</a>
+                </div>
+            </div>
+            <div class="kdn-animate">
+                <div class="kdn-card">
+                    <h2 class="kdn-card__title">Shop Services</h2>
+                    <ul class="kdn-card__text" style="display:grid; gap:0.75rem; list-style:none; padding:0;">
+                        <li>• Complimentary tailoring on qualifying orders.</li>
+                        <li>• Express global shipping on orders over $150.</li>
+                        <li>• Access to members-only mystery drops each solstice.</li>
+                        <li>• Earn points every time you wield CEBASTIAN gear.</li>
+                    </ul>
+                    <a class="kdn-btn kdn-btn--outline" href="/my-account/#dashboard">Join the Loyalty Guild</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" id="catalog" aria-labelledby="categories-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <p class="kdn-pill">Collections</p>
+            <h2 id="categories-title" class="kdn-title">Shop by Realm</h2>
+            <p class="kdn-subtitle">Navigate our curated categories—outerwear forged for frost, essentials honed for city quests, and accessories to complete the lore.</p>
+        </header>
+        <div class="kdn-animate">
+            <!-- WooCommerce Shortcode -->
+            <div class="woocommerce-shortcode">[product_categories number="4" columns="4" hide_empty="false"]</div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="filters-title">
+    <div class="kdn-container">
+        <div class="kdn-card kdn-animate">
+            <h2 id="filters-title" class="kdn-card__title">Power-Up Filters</h2>
+            <div class="kdn-grid kdn-grid--3" style="margin-top:1.5rem;">
+                <div class="kdn-stat">
+                    <p class="kdn-stat__value">Aura</p>
+                    <p class="kdn-stat__label">Neon, Eclipse, Ether</p>
+                </div>
+                <div class="kdn-stat">
+                    <p class="kdn-stat__value">Armor</p>
+                    <p class="kdn-stat__label">Outerwear, Tops, Bottoms</p>
+                </div>
+                <div class="kdn-stat">
+                    <p class="kdn-stat__value">Rarity</p>
+                    <p class="kdn-stat__label">Core, Limited, Archive</p>
+                </div>
+            </div>
+            <p class="kdn-card__text" style="margin-top:1.5rem;">Use the sorting controls below to toggle through release dates, price points, and popularity. Combine filters to manifest your ideal fit.</p>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" id="shop-grid" aria-labelledby="catalog-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">All Products</span>
+            <h2 id="catalog-title" class="kdn-title">Full Catalog</h2>
+            <p class="kdn-subtitle">Scroll through the complete CEBASTIAN inventory. The shortcode below respects WooCommerce sorting, filters, and pagination.</p>
+        </header>
+        <div class="kdn-animate">
+            <!-- WooCommerce Shortcode -->
+            <div class="woocommerce-shortcode">[products paginate="true" columns="4" limit="12"]</div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section kdn-section--featured" aria-labelledby="bestsellers-title">
+    <div class="kdn-container">
+        <header class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Fan Favorites</span>
+            <h2 id="bestsellers-title" class="kdn-title">Best Sellers</h2>
+            <p class="kdn-subtitle">Claim pieces that continuously sell out—these staples anchor every legendary wardrobe.</p>
+        </header>
+        <div class="kdn-animate">
+            <!-- WooCommerce Shortcode -->
+            <div class="woocommerce-shortcode">[best_selling_products limit="4" columns="4"]</div>
+        </div>
+    </div>
+</section>
+
+<section class="kdn-section" aria-labelledby="archive-title">
+    <div class="kdn-container">
+        <div class="kdn-section__header kdn-animate">
+            <span class="kdn-pill">Vault</span>
+            <h2 id="archive-title" class="kdn-title">Archive Drops</h2>
+            <p class="kdn-subtitle">Relive rare silhouettes that defined our story. When they re-emerge, newsletter subscribers are the first to know.</p>
+        </div>
+        <div class="kdn-grid kdn-grid--3">
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">Drop 01</span>
+                <h3 class="kdn-card__title">Celestial Vanguard</h3>
+                <p class="kdn-card__text">Where it all began—obsidian hoodies with glow-thread sigils, sold out in 26 hours.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">Drop 05</span>
+                <h3 class="kdn-card__title">Chromatic Echoes</h3>
+                <p class="kdn-card__text">Reflective denim suits crafted with prismatic foil overlays for night riders.</p>
+            </article>
+            <article class="kdn-card kdn-animate">
+                <span class="kdn-card__eyebrow">Drop 08</span>
+                <h3 class="kdn-card__title">Mythos Tactical</h3>
+                <p class="kdn-card__text">Convertible trench with concealed harness and stormproof venting for covert missions.</p>
+            </article>
+        </div>
+        <div style="text-align:center; margin-top:2.5rem;" class="kdn-animate">
+            <a class="kdn-btn kdn-btn--outline" href="/newsletter/">Get Archive Alerts</a>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add node-based tests that validate the CEBASTIAN Additional CSS for accessibility affordances and structural integrity
- reinforce newsletter and contact form focus treatments to preserve visible keyboard outlines across the site

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ce2a80227c8325a7c9058e6467c9cd